### PR TITLE
ARToolKit v5.3.1 win32-vs100 compability.

### DIFF
--- a/VisualStudio/vs100/ARvideo.vcxproj.filters
+++ b/VisualStudio/vs100/ARvideo.vcxproj.filters
@@ -1,0 +1,98 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<Project ToolsVersion="4.0" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+  <ItemGroup>
+    <ClCompile Include="..\..\lib\SRC\Video\video.c" />
+    <ClCompile Include="..\..\lib\SRC\Video\video2.c" />
+    <ClCompile Include="..\..\lib\SRC\Video\videoSaveImage.c" />
+    <ClCompile Include="..\..\lib\SRC\Video\videoAspectRatio.c" />
+    <ClCompile Include="..\..\lib\SRC\VideoDummy\videoDummy.c">
+      <Filter>Dummy</Filter>
+    </ClCompile>
+    <ClCompile Include="..\..\lib\SRC\VideoImage\videoImage.c">
+      <Filter>Image</Filter>
+    </ClCompile>
+    <ClCompile Include="..\..\lib\SRC\VideoQuickTime\videoQuickTime.c">
+      <Filter>QUICKTIME</Filter>
+    </ClCompile>
+    <ClCompile Include="..\..\lib\SRC\VideoQuickTime\videoQuickTimeMovie.c">
+      <Filter>QUICKTIME</Filter>
+    </ClCompile>
+    <ClCompile Include="..\..\lib\SRC\VideoWinDF\videoWinDF.cpp">
+      <Filter>WinDF</Filter>
+    </ClCompile>
+    <ClCompile Include="..\..\lib\SRC\VideoWinMF\LogMediaType.cpp">
+      <Filter>WinMF</Filter>
+    </ClCompile>
+    <ClCompile Include="..\..\lib\SRC\VideoWinMF\videoWinMF.cpp">
+      <Filter>WinMF</Filter>
+    </ClCompile>
+    <ClCompile Include="..\..\lib\SRC\VideoWinDS\videoWinDS.cpp">
+      <Filter>WinDS</Filter>
+    </ClCompile>
+    <ClCompile Include="..\..\lib\SRC\VideoWinDSVL\videoWinDSVL.cpp">
+      <Filter>WinDSVL</Filter>
+    </ClCompile>
+  </ItemGroup>
+  <ItemGroup>
+    <ClInclude Include="..\..\include\AR\ar.h" />
+    <ClInclude Include="..\..\include\AR\arConfig.h" />
+    <ClInclude Include="..\..\include\AR\config.h" />
+    <ClInclude Include="..\..\include\AR\matrix.h" />
+    <ClInclude Include="..\..\include\AR\param.h" />
+    <ClInclude Include="..\..\include\AR\video.h" />
+    <ClInclude Include="..\..\include\AR\videoConfig.h" />
+    <ClInclude Include="..\..\include\AR\sys\videoDummy.h">
+      <Filter>Dummy</Filter>
+    </ClInclude>
+    <ClInclude Include="..\..\include\AR\sys\videoImage.h">
+      <Filter>Image</Filter>
+    </ClInclude>
+    <ClInclude Include="..\..\include\AR\sys\videoQuickTime.h">
+      <Filter>QUICKTIME</Filter>
+    </ClInclude>
+    <ClInclude Include="..\..\include\AR\sys\videoQuickTimeMovie.h">
+      <Filter>QUICKTIME</Filter>
+    </ClInclude>
+    <ClInclude Include="..\..\include\AR\sys\videoWindowsDragonFly.h">
+      <Filter>WinDF</Filter>
+    </ClInclude>
+    <ClInclude Include="..\..\lib\SRC\VideoWinMF\BufferLock.h">
+      <Filter>WinMF</Filter>
+    </ClInclude>
+    <ClInclude Include="..\..\include\AR\sys\videoWindowsMediaFoundation.h">
+      <Filter>WinMF</Filter>
+    </ClInclude>
+    <ClInclude Include="..\..\lib\SRC\VideoWinDS\videoWinDSPrivate.h">
+      <Filter>WinDS</Filter>
+    </ClInclude>
+    <ClInclude Include="..\..\include\AR\sys\videoWindowsDirectShow.h">
+      <Filter>WinDS</Filter>
+    </ClInclude>
+    <ClInclude Include="..\..\include\Ar\sys\videoWindowsDSVideoLib.h">
+      <Filter>WinDSVL</Filter>
+    </ClInclude>
+  </ItemGroup>
+  <ItemGroup>
+    <Filter Include="Dummy">
+      <UniqueIdentifier>{41ea9781-da6a-4615-9536-65cb3c7cd63d}</UniqueIdentifier>
+    </Filter>
+    <Filter Include="Image">
+      <UniqueIdentifier>{2d7e7398-e3a1-4dc4-b67b-1196a7968229}</UniqueIdentifier>
+    </Filter>
+    <Filter Include="QUICKTIME">
+      <UniqueIdentifier>{16036569-2faa-41d8-a7bc-8758a34ea3f3}</UniqueIdentifier>
+    </Filter>
+    <Filter Include="WinMF">
+      <UniqueIdentifier>{867a4534-9e35-43e5-93d2-18800e7e63ea}</UniqueIdentifier>
+    </Filter>
+    <Filter Include="WinDS">
+      <UniqueIdentifier>{85cc3762-adda-46f9-8188-3d1878759b2b}</UniqueIdentifier>
+    </Filter>
+    <Filter Include="WinDSVL">
+      <UniqueIdentifier>{15e1f2b5-0467-4135-84de-8176c56ebc3c}</UniqueIdentifier>
+    </Filter>
+    <Filter Include="WinDF">
+      <UniqueIdentifier>{e113ddd5-9b47-4806-b776-34be902131f9}</UniqueIdentifier>
+    </Filter>
+  </ItemGroup>
+</Project>

--- a/VisualStudio/vs100/KPM.vcxproj
+++ b/VisualStudio/vs100/KPM.vcxproj
@@ -136,7 +136,7 @@
   <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Debug|Win32'">
     <ClCompile>
       <Optimization>Disabled</Optimization>
-      <AdditionalIncludeDirectories>$(ProjectDir)..\..\include\win32-i386;$(ProjectDir)..\..\include;%(AdditionalIncludeDirectories)</AdditionalIncludeDirectories>
+      <AdditionalIncludeDirectories>$(ProjectDir)..\..\lib\SRC\KPM\FreakMatcher;$(ProjectDir)..\..\include\win32-i386;$(ProjectDir)..\..\include;%(AdditionalIncludeDirectories)</AdditionalIncludeDirectories>
       <PreprocessorDefinitions>WIN32;_DEBUG;_LIB;_CRT_SECURE_NO_DEPRECATE;%(PreprocessorDefinitions)</PreprocessorDefinitions>
       <MinimalRebuild>false</MinimalRebuild>
       <BasicRuntimeChecks>EnableFastChecks</BasicRuntimeChecks>
@@ -146,12 +146,13 @@
       <WarningLevel>Level3</WarningLevel>
       <DebugInformationFormat>
       </DebugInformationFormat>
+      <DisableSpecificWarnings>4018;4244;4290;4305;4521;4522</DisableSpecificWarnings>
     </ClCompile>
     <Lib />
   </ItemDefinitionGroup>
   <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Release|Win32'">
     <ClCompile>
-      <AdditionalIncludeDirectories>$(ProjectDir)..\..\include\win32-i386;$(ProjectDir)..\..\include;%(AdditionalIncludeDirectories)</AdditionalIncludeDirectories>
+      <AdditionalIncludeDirectories>$(ProjectDir)..\..\lib\SRC\KPM\FreakMatcher;$(ProjectDir)..\..\include\win32-i386;$(ProjectDir)..\..\include;%(AdditionalIncludeDirectories)</AdditionalIncludeDirectories>
       <PreprocessorDefinitions>WIN32;NDEBUG;_LIB;_CRT_SECURE_NO_DEPRECATE;%(PreprocessorDefinitions)</PreprocessorDefinitions>
       <RuntimeLibrary>MultiThreadedDLL</RuntimeLibrary>
       <PrecompiledHeader>
@@ -159,13 +160,14 @@
       <WarningLevel>Level3</WarningLevel>
       <DebugInformationFormat>
       </DebugInformationFormat>
+      <DisableSpecificWarnings>4018;4244;4290;4305;4521;4522</DisableSpecificWarnings>
     </ClCompile>
     <Lib />
   </ItemDefinitionGroup>
   <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Debug-StaticCRuntime|Win32'">
     <ClCompile>
       <Optimization>Disabled</Optimization>
-      <AdditionalIncludeDirectories>$(ProjectDir)..\..\include\win32-i386;$(ProjectDir)..\..\include;%(AdditionalIncludeDirectories)</AdditionalIncludeDirectories>
+      <AdditionalIncludeDirectories>$(ProjectDir)..\..\lib\SRC\KPM\FreakMatcher;$(ProjectDir)..\..\include\win32-i386;$(ProjectDir)..\..\include;%(AdditionalIncludeDirectories)</AdditionalIncludeDirectories>
       <PreprocessorDefinitions>WIN32;_DEBUG;_LIB;_CRT_SECURE_NO_DEPRECATE;%(PreprocessorDefinitions)</PreprocessorDefinitions>
       <MinimalRebuild>false</MinimalRebuild>
       <BasicRuntimeChecks>EnableFastChecks</BasicRuntimeChecks>
@@ -175,12 +177,13 @@
       <WarningLevel>Level3</WarningLevel>
       <DebugInformationFormat>
       </DebugInformationFormat>
+      <DisableSpecificWarnings>4018;4244;4290;4305;4521;4522</DisableSpecificWarnings>
     </ClCompile>
     <Lib />
   </ItemDefinitionGroup>
   <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Release-StaticCRuntime|Win32'">
     <ClCompile>
-      <AdditionalIncludeDirectories>$(ProjectDir)..\..\include\win32-i386;$(ProjectDir)..\..\include;%(AdditionalIncludeDirectories)</AdditionalIncludeDirectories>
+      <AdditionalIncludeDirectories>$(ProjectDir)..\..\lib\SRC\KPM\FreakMatcher;$(ProjectDir)..\..\include\win32-i386;$(ProjectDir)..\..\include;%(AdditionalIncludeDirectories)</AdditionalIncludeDirectories>
       <PreprocessorDefinitions>WIN32;NDEBUG;_LIB;_CRT_SECURE_NO_DEPRECATE;%(PreprocessorDefinitions)</PreprocessorDefinitions>
       <RuntimeLibrary>MultiThreaded</RuntimeLibrary>
       <PrecompiledHeader>
@@ -188,6 +191,7 @@
       <WarningLevel>Level3</WarningLevel>
       <DebugInformationFormat>
       </DebugInformationFormat>
+      <DisableSpecificWarnings>4018;4244;4290;4305;4521;4522</DisableSpecificWarnings>
     </ClCompile>
     <Lib />
   </ItemDefinitionGroup>
@@ -197,7 +201,7 @@
     </Midl>
     <ClCompile>
       <Optimization>Disabled</Optimization>
-      <AdditionalIncludeDirectories>$(ProjectDir)..\..\include\win64-x64;$(ProjectDir)..\..\include;%(AdditionalIncludeDirectories)</AdditionalIncludeDirectories>
+      <AdditionalIncludeDirectories>$(ProjectDir)..\..\lib\SRC\KPM\FreakMatcher;$(ProjectDir)..\..\include\win64-x64;$(ProjectDir)..\..\include;%(AdditionalIncludeDirectories)</AdditionalIncludeDirectories>
       <PreprocessorDefinitions>WIN32;_DEBUG;_LIB;_CRT_SECURE_NO_DEPRECATE;%(PreprocessorDefinitions)</PreprocessorDefinitions>
       <MinimalRebuild>false</MinimalRebuild>
       <BasicRuntimeChecks>EnableFastChecks</BasicRuntimeChecks>
@@ -207,6 +211,7 @@
       <WarningLevel>Level3</WarningLevel>
       <DebugInformationFormat>
       </DebugInformationFormat>
+      <DisableSpecificWarnings>4018;4244;4290;4305;4521;4522</DisableSpecificWarnings>
     </ClCompile>
     <Lib />
   </ItemDefinitionGroup>
@@ -215,7 +220,7 @@
       <TargetEnvironment>X64</TargetEnvironment>
     </Midl>
     <ClCompile>
-      <AdditionalIncludeDirectories>$(ProjectDir)..\..\include\win64-x64;$(ProjectDir)..\..\include;%(AdditionalIncludeDirectories)</AdditionalIncludeDirectories>
+      <AdditionalIncludeDirectories>$(ProjectDir)..\..\lib\SRC\KPM\FreakMatcher;$(ProjectDir)..\..\include\win64-x64;$(ProjectDir)..\..\include;%(AdditionalIncludeDirectories)</AdditionalIncludeDirectories>
       <PreprocessorDefinitions>WIN32;NDEBUG;_LIB;_CRT_SECURE_NO_DEPRECATE;%(PreprocessorDefinitions)</PreprocessorDefinitions>
       <RuntimeLibrary>MultiThreadedDLL</RuntimeLibrary>
       <PrecompiledHeader>
@@ -223,6 +228,7 @@
       <WarningLevel>Level3</WarningLevel>
       <DebugInformationFormat>
       </DebugInformationFormat>
+      <DisableSpecificWarnings>4018;4244;4290;4305;4521;4522</DisableSpecificWarnings>
     </ClCompile>
     <Lib />
   </ItemDefinitionGroup>
@@ -232,7 +238,7 @@
     </Midl>
     <ClCompile>
       <Optimization>Disabled</Optimization>
-      <AdditionalIncludeDirectories>$(ProjectDir)..\..\include\win64-x64;$(ProjectDir)..\..\include;%(AdditionalIncludeDirectories)</AdditionalIncludeDirectories>
+      <AdditionalIncludeDirectories>$(ProjectDir)..\..\lib\SRC\KPM\FreakMatcher;$(ProjectDir)..\..\include\win64-x64;$(ProjectDir)..\..\include;%(AdditionalIncludeDirectories)</AdditionalIncludeDirectories>
       <PreprocessorDefinitions>WIN32;_DEBUG;_LIB;_CRT_SECURE_NO_DEPRECATE;%(PreprocessorDefinitions)</PreprocessorDefinitions>
       <MinimalRebuild>false</MinimalRebuild>
       <BasicRuntimeChecks>EnableFastChecks</BasicRuntimeChecks>
@@ -242,6 +248,7 @@
       <WarningLevel>Level3</WarningLevel>
       <DebugInformationFormat>
       </DebugInformationFormat>
+      <DisableSpecificWarnings>4018;4244;4290;4305;4521;4522</DisableSpecificWarnings>
     </ClCompile>
     <Lib />
   </ItemDefinitionGroup>
@@ -250,7 +257,7 @@
       <TargetEnvironment>X64</TargetEnvironment>
     </Midl>
     <ClCompile>
-      <AdditionalIncludeDirectories>$(ProjectDir)..\..\include\win64-x64;$(ProjectDir)..\..\include;%(AdditionalIncludeDirectories)</AdditionalIncludeDirectories>
+      <AdditionalIncludeDirectories>$(ProjectDir)..\..\lib\SRC\KPM\FreakMatcher;$(ProjectDir)..\..\include\win64-x64;$(ProjectDir)..\..\include;%(AdditionalIncludeDirectories)</AdditionalIncludeDirectories>
       <PreprocessorDefinitions>WIN32;NDEBUG;_LIB;_CRT_SECURE_NO_DEPRECATE;%(PreprocessorDefinitions)</PreprocessorDefinitions>
       <RuntimeLibrary>MultiThreaded</RuntimeLibrary>
       <PrecompiledHeader>
@@ -258,31 +265,106 @@
       <WarningLevel>Level3</WarningLevel>
       <DebugInformationFormat>
       </DebugInformationFormat>
+      <DisableSpecificWarnings>4018;4244;4290;4305;4521;4522</DisableSpecificWarnings>
     </ClCompile>
     <Lib />
   </ItemDefinitionGroup>
   <ItemGroup>
-    <ClCompile Include="..\..\lib\SRC\KPM\AnnMatch.cpp" />
-    <ClCompile Include="..\..\lib\SRC\KPM\AnnMatch2.cpp" />
-    <ClCompile Include="..\..\lib\SRC\KPM\HomographyEst.cpp" />
+    <ClCompile Include="..\..\lib\SRC\KPM\FreakMatcher\detectors\DoG_scale_invariant_detector.cpp" />
+    <ClCompile Include="..\..\lib\SRC\KPM\FreakMatcher\detectors\gaussian_scale_space_pyramid.cpp" />
+    <ClCompile Include="..\..\lib\SRC\KPM\FreakMatcher\detectors\gradients.cpp" />
+    <ClCompile Include="..\..\lib\SRC\KPM\FreakMatcher\detectors\harris.cpp" />
+    <ClCompile Include="..\..\lib\SRC\KPM\FreakMatcher\detectors\orientation_assignment.cpp" />
+    <ClCompile Include="..\..\lib\SRC\KPM\FreakMatcher\detectors\pyramid.cpp" />
+    <ClCompile Include="..\..\lib\SRC\KPM\FreakMatcher\facade\visual_database_facade.cpp" />
+    <ClCompile Include="..\..\lib\SRC\KPM\FreakMatcher\framework\date_time.cpp" />
+    <ClCompile Include="..\..\lib\SRC\KPM\FreakMatcher\framework\image.cpp" />
+    <ClCompile Include="..\..\lib\SRC\KPM\FreakMatcher\framework\logger.cpp" />
+    <ClCompile Include="..\..\lib\SRC\KPM\FreakMatcher\framework\timers.cpp" />
+    <ClCompile Include="..\..\lib\SRC\KPM\FreakMatcher\matchers\freak.cpp" />
+    <ClCompile Include="..\..\lib\SRC\KPM\FreakMatcher\matchers\hough_similarity_voting.cpp" />
     <ClCompile Include="..\..\lib\SRC\KPM\kpmFopen.c" />
     <ClCompile Include="..\..\lib\SRC\KPM\kpmHandle.cpp" />
     <ClCompile Include="..\..\lib\SRC\KPM\kpmMatching.cpp" />
     <ClCompile Include="..\..\lib\SRC\KPM\kpmRefDataSet.cpp" />
     <ClCompile Include="..\..\lib\SRC\KPM\kpmResult.cpp" />
     <ClCompile Include="..\..\lib\SRC\KPM\kpmUtil.cpp" />
-    <ClCompile Include="..\..\lib\SRC\KPM\surfSub1.cpp" />
-    <ClCompile Include="..\..\lib\SRC\KPM\surfSub2.cpp" />
   </ItemGroup>
   <ItemGroup>
     <ClInclude Include="..\..\include\KPM\kpm.h" />
     <ClInclude Include="..\..\include\KPM\kpmType.h" />
-    <ClInclude Include="..\..\include\KPM\surfSub.h" />
-    <ClInclude Include="..\..\lib\SRC\KPM\AnnMatch.h" />
-    <ClInclude Include="..\..\lib\SRC\KPM\AnnMatch2.h" />
-    <ClInclude Include="..\..\lib\SRC\KPM\HomographyEst.h" />
+    <ClInclude Include="..\..\lib\SRC\KPM\FreakMatcher\detectors\DoG_scale_invariant_detector.h" />
+    <ClInclude Include="..\..\lib\SRC\KPM\FreakMatcher\detectors\gaussian_scale_space_pyramid.h" />
+    <ClInclude Include="..\..\lib\SRC\KPM\FreakMatcher\detectors\gradients.h" />
+    <ClInclude Include="..\..\lib\SRC\KPM\FreakMatcher\detectors\harris-inline.h" />
+    <ClInclude Include="..\..\lib\SRC\KPM\FreakMatcher\detectors\harris.h" />
+    <ClInclude Include="..\..\lib\SRC\KPM\FreakMatcher\detectors\interpolate.h" />
+    <ClInclude Include="..\..\lib\SRC\KPM\FreakMatcher\detectors\orientation_assignment.h" />
+    <ClInclude Include="..\..\lib\SRC\KPM\FreakMatcher\detectors\pyramid-inline.h" />
+    <ClInclude Include="..\..\lib\SRC\KPM\FreakMatcher\detectors\pyramid.h" />
+    <ClInclude Include="..\..\lib\SRC\KPM\FreakMatcher\facade\visual_database_facade.h" />
+    <ClInclude Include="..\..\lib\SRC\KPM\FreakMatcher\framework\date_time.h" />
+    <ClInclude Include="..\..\lib\SRC\KPM\FreakMatcher\framework\error.h" />
+    <ClInclude Include="..\..\lib\SRC\KPM\FreakMatcher\framework\exception.h" />
+    <ClInclude Include="..\..\lib\SRC\KPM\FreakMatcher\framework\image.h" />
+    <ClInclude Include="..\..\lib\SRC\KPM\FreakMatcher\framework\image_utils.h" />
+    <ClInclude Include="..\..\lib\SRC\KPM\FreakMatcher\framework\logger.h" />
+    <ClInclude Include="..\..\lib\SRC\KPM\FreakMatcher\framework\timers.h" />
+    <ClInclude Include="..\..\lib\SRC\KPM\FreakMatcher\homography_estimation\homography_solver.h" />
+    <ClInclude Include="..\..\lib\SRC\KPM\FreakMatcher\homography_estimation\robust_homography.h" />
+    <ClInclude Include="..\..\lib\SRC\KPM\FreakMatcher\matchers\binary_hierarchical_clustering.h" />
+    <ClInclude Include="..\..\lib\SRC\KPM\FreakMatcher\matchers\feature_matcher-inline.h" />
+    <ClInclude Include="..\..\lib\SRC\KPM\FreakMatcher\matchers\feature_matcher.h" />
+    <ClInclude Include="..\..\lib\SRC\KPM\FreakMatcher\matchers\feature_point.h" />
+    <ClInclude Include="..\..\lib\SRC\KPM\FreakMatcher\matchers\feature_store.h" />
+    <ClInclude Include="..\..\lib\SRC\KPM\FreakMatcher\matchers\freak.h" />
+    <ClInclude Include="..\..\lib\SRC\KPM\FreakMatcher\matchers\freak84-inline.h" />
+    <ClInclude Include="..\..\lib\SRC\KPM\FreakMatcher\matchers\hough_similarity_voting.h" />
+    <ClInclude Include="..\..\lib\SRC\KPM\FreakMatcher\matchers\keyframe.h" />
+    <ClInclude Include="..\..\lib\SRC\KPM\FreakMatcher\matchers\kmedoids.h" />
+    <ClInclude Include="..\..\lib\SRC\KPM\FreakMatcher\matchers\matcher_types.h" />
+    <ClInclude Include="..\..\lib\SRC\KPM\FreakMatcher\matchers\visual_database-inline.h" />
+    <ClInclude Include="..\..\lib\SRC\KPM\FreakMatcher\matchers\visual_database.h" />
+    <ClInclude Include="..\..\lib\SRC\KPM\FreakMatcher\matchers\visual_database_types.h" />
+    <ClInclude Include="..\..\lib\SRC\KPM\FreakMatcher\math\cholesky.h" />
+    <ClInclude Include="..\..\lib\SRC\KPM\FreakMatcher\math\cholesky_linear_solvers.h" />
+    <ClInclude Include="..\..\lib\SRC\KPM\FreakMatcher\math\geometry.h" />
+    <ClInclude Include="..\..\lib\SRC\KPM\FreakMatcher\math\hamming.h" />
+    <ClInclude Include="..\..\lib\SRC\KPM\FreakMatcher\math\homography.h" />
+    <ClInclude Include="..\..\lib\SRC\KPM\FreakMatcher\math\indexing.h" />
+    <ClInclude Include="..\..\lib\SRC\KPM\FreakMatcher\math\linear_algebra.h" />
+    <ClInclude Include="..\..\lib\SRC\KPM\FreakMatcher\math\linear_solvers.h" />
+    <ClInclude Include="..\..\lib\SRC\KPM\FreakMatcher\math\math_utils.h" />
+    <ClInclude Include="..\..\lib\SRC\KPM\FreakMatcher\math\matrix.h" />
+    <ClInclude Include="..\..\lib\SRC\KPM\FreakMatcher\math\polynomial.h" />
+    <ClInclude Include="..\..\lib\SRC\KPM\FreakMatcher\math\quaternion.h" />
+    <ClInclude Include="..\..\lib\SRC\KPM\FreakMatcher\math\rand.h" />
+    <ClInclude Include="..\..\lib\SRC\KPM\FreakMatcher\math\robustifiers.h" />
+    <ClInclude Include="..\..\lib\SRC\KPM\FreakMatcher\utils\feature_drawing.h" />
+    <ClInclude Include="..\..\lib\SRC\KPM\FreakMatcher\utils\partial_sort.h" />
+    <ClInclude Include="..\..\lib\SRC\KPM\FreakMatcher\utils\point.h" />
     <ClInclude Include="..\..\lib\SRC\KPM\kpmFopen.h" />
-    <ClInclude Include="..\..\lib\SRC\KPM\surfSubPrivate.h" />
+  </ItemGroup>
+  <ItemGroup>
+    <None Include="..\..\lib\SRC\KPM\FreakMatcher\Eigen\Array" />
+    <None Include="..\..\lib\SRC\KPM\FreakMatcher\Eigen\Cholesky" />
+    <None Include="..\..\lib\SRC\KPM\FreakMatcher\Eigen\Core" />
+    <None Include="..\..\lib\SRC\KPM\FreakMatcher\Eigen\Dense" />
+    <None Include="..\..\lib\SRC\KPM\FreakMatcher\Eigen\Eigen" />
+    <None Include="..\..\lib\SRC\KPM\FreakMatcher\Eigen\Eigen2Support" />
+    <None Include="..\..\lib\SRC\KPM\FreakMatcher\Eigen\Eigenvalues" />
+    <None Include="..\..\lib\SRC\KPM\FreakMatcher\Eigen\Geometry" />
+    <None Include="..\..\lib\SRC\KPM\FreakMatcher\Eigen\Householder" />
+    <None Include="..\..\lib\SRC\KPM\FreakMatcher\Eigen\Jacobi" />
+    <None Include="..\..\lib\SRC\KPM\FreakMatcher\Eigen\LeastSquares" />
+    <None Include="..\..\lib\SRC\KPM\FreakMatcher\Eigen\LU" />
+    <None Include="..\..\lib\SRC\KPM\FreakMatcher\Eigen\QR" />
+    <None Include="..\..\lib\SRC\KPM\FreakMatcher\Eigen\QtAlignedMalloc" />
+    <None Include="..\..\lib\SRC\KPM\FreakMatcher\Eigen\Sparse" />
+    <None Include="..\..\lib\SRC\KPM\FreakMatcher\Eigen\StdDeque" />
+    <None Include="..\..\lib\SRC\KPM\FreakMatcher\Eigen\StdList" />
+    <None Include="..\..\lib\SRC\KPM\FreakMatcher\Eigen\StdVector" />
+    <None Include="..\..\lib\SRC\KPM\FreakMatcher\Eigen\SVD" />
   </ItemGroup>
   <Import Project="$(VCTargetsPath)\Microsoft.Cpp.targets" />
   <ImportGroup Label="ExtensionTargets">

--- a/VisualStudio/vs100/KPM.vcxproj.filters
+++ b/VisualStudio/vs100/KPM.vcxproj.filters
@@ -1,0 +1,303 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<Project ToolsVersion="4.0" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+  <ItemGroup>
+    <ClCompile Include="..\..\lib\SRC\KPM\kpmFopen.c" />
+    <ClCompile Include="..\..\lib\SRC\KPM\kpmHandle.cpp" />
+    <ClCompile Include="..\..\lib\SRC\KPM\kpmMatching.cpp" />
+    <ClCompile Include="..\..\lib\SRC\KPM\kpmRefDataSet.cpp" />
+    <ClCompile Include="..\..\lib\SRC\KPM\kpmResult.cpp" />
+    <ClCompile Include="..\..\lib\SRC\KPM\kpmUtil.cpp" />
+    <ClCompile Include="..\..\lib\SRC\KPM\FreakMatcher\detectors\DoG_scale_invariant_detector.cpp">
+      <Filter>FreakMatcher\detectors</Filter>
+    </ClCompile>
+    <ClCompile Include="..\..\lib\SRC\KPM\FreakMatcher\detectors\gaussian_scale_space_pyramid.cpp">
+      <Filter>FreakMatcher\detectors</Filter>
+    </ClCompile>
+    <ClCompile Include="..\..\lib\SRC\KPM\FreakMatcher\detectors\gradients.cpp">
+      <Filter>FreakMatcher\detectors</Filter>
+    </ClCompile>
+    <ClCompile Include="..\..\lib\SRC\KPM\FreakMatcher\detectors\harris.cpp">
+      <Filter>FreakMatcher\detectors</Filter>
+    </ClCompile>
+    <ClCompile Include="..\..\lib\SRC\KPM\FreakMatcher\detectors\orientation_assignment.cpp">
+      <Filter>FreakMatcher\detectors</Filter>
+    </ClCompile>
+    <ClCompile Include="..\..\lib\SRC\KPM\FreakMatcher\detectors\pyramid.cpp">
+      <Filter>FreakMatcher\detectors</Filter>
+    </ClCompile>
+    <ClCompile Include="..\..\lib\SRC\KPM\FreakMatcher\facade\visual_database_facade.cpp">
+      <Filter>FreakMatcher\facade</Filter>
+    </ClCompile>
+    <ClCompile Include="..\..\lib\SRC\KPM\FreakMatcher\framework\date_time.cpp">
+      <Filter>FreakMatcher\framework</Filter>
+    </ClCompile>
+    <ClCompile Include="..\..\lib\SRC\KPM\FreakMatcher\framework\image.cpp">
+      <Filter>FreakMatcher\framework</Filter>
+    </ClCompile>
+    <ClCompile Include="..\..\lib\SRC\KPM\FreakMatcher\framework\logger.cpp">
+      <Filter>FreakMatcher\framework</Filter>
+    </ClCompile>
+    <ClCompile Include="..\..\lib\SRC\KPM\FreakMatcher\framework\timers.cpp">
+      <Filter>FreakMatcher\framework</Filter>
+    </ClCompile>
+    <ClCompile Include="..\..\lib\SRC\KPM\FreakMatcher\matchers\freak.cpp">
+      <Filter>FreakMatcher\matchers</Filter>
+    </ClCompile>
+    <ClCompile Include="..\..\lib\SRC\KPM\FreakMatcher\matchers\hough_similarity_voting.cpp">
+      <Filter>FreakMatcher\matchers</Filter>
+    </ClCompile>
+  </ItemGroup>
+  <ItemGroup>
+    <ClInclude Include="..\..\include\KPM\kpm.h" />
+    <ClInclude Include="..\..\include\KPM\kpmType.h" />
+    <ClInclude Include="..\..\lib\SRC\KPM\kpmFopen.h" />
+    <ClInclude Include="..\..\lib\SRC\KPM\kpmPrivate.h" />
+    <ClInclude Include="..\..\lib\SRC\KPM\FreakMatcher\detectors\DoG_scale_invariant_detector.h">
+      <Filter>FreakMatcher\detectors</Filter>
+    </ClInclude>
+    <ClInclude Include="..\..\lib\SRC\KPM\FreakMatcher\detectors\gaussian_scale_space_pyramid.h">
+      <Filter>FreakMatcher\detectors</Filter>
+    </ClInclude>
+    <ClInclude Include="..\..\lib\SRC\KPM\FreakMatcher\detectors\gradients.h">
+      <Filter>FreakMatcher\detectors</Filter>
+    </ClInclude>
+    <ClInclude Include="..\..\lib\SRC\KPM\FreakMatcher\detectors\harris.h">
+      <Filter>FreakMatcher\detectors</Filter>
+    </ClInclude>
+    <ClInclude Include="..\..\lib\SRC\KPM\FreakMatcher\detectors\harris-inline.h">
+      <Filter>FreakMatcher\detectors</Filter>
+    </ClInclude>
+    <ClInclude Include="..\..\lib\SRC\KPM\FreakMatcher\detectors\interpolate.h">
+      <Filter>FreakMatcher\detectors</Filter>
+    </ClInclude>
+    <ClInclude Include="..\..\lib\SRC\KPM\FreakMatcher\detectors\orientation_assignment.h">
+      <Filter>FreakMatcher\detectors</Filter>
+    </ClInclude>
+    <ClInclude Include="..\..\lib\SRC\KPM\FreakMatcher\detectors\pyramid.h">
+      <Filter>FreakMatcher\detectors</Filter>
+    </ClInclude>
+    <ClInclude Include="..\..\lib\SRC\KPM\FreakMatcher\detectors\pyramid-inline.h">
+      <Filter>FreakMatcher\detectors</Filter>
+    </ClInclude>
+    <ClInclude Include="..\..\lib\SRC\KPM\FreakMatcher\facade\visual_database_facade.h">
+      <Filter>FreakMatcher\facade</Filter>
+    </ClInclude>
+    <ClInclude Include="..\..\lib\SRC\KPM\FreakMatcher\framework\date_time.h">
+      <Filter>FreakMatcher\framework</Filter>
+    </ClInclude>
+    <ClInclude Include="..\..\lib\SRC\KPM\FreakMatcher\framework\error.h">
+      <Filter>FreakMatcher\framework</Filter>
+    </ClInclude>
+    <ClInclude Include="..\..\lib\SRC\KPM\FreakMatcher\framework\exception.h">
+      <Filter>FreakMatcher\framework</Filter>
+    </ClInclude>
+    <ClInclude Include="..\..\lib\SRC\KPM\FreakMatcher\framework\image.h">
+      <Filter>FreakMatcher\framework</Filter>
+    </ClInclude>
+    <ClInclude Include="..\..\lib\SRC\KPM\FreakMatcher\framework\image_utils.h">
+      <Filter>FreakMatcher\framework</Filter>
+    </ClInclude>
+    <ClInclude Include="..\..\lib\SRC\KPM\FreakMatcher\framework\logger.h">
+      <Filter>FreakMatcher\framework</Filter>
+    </ClInclude>
+    <ClInclude Include="..\..\lib\SRC\KPM\FreakMatcher\framework\timers.h">
+      <Filter>FreakMatcher\framework</Filter>
+    </ClInclude>
+    <ClInclude Include="..\..\lib\SRC\KPM\FreakMatcher\homography_estimation\homography_solver.h">
+      <Filter>FreakMatcher\homography_estimation</Filter>
+    </ClInclude>
+    <ClInclude Include="..\..\lib\SRC\KPM\FreakMatcher\homography_estimation\robust_homography.h">
+      <Filter>FreakMatcher\homography_estimation</Filter>
+    </ClInclude>
+    <ClInclude Include="..\..\lib\SRC\KPM\FreakMatcher\matchers\binary_hierarchical_clustering.h">
+      <Filter>FreakMatcher\matchers</Filter>
+    </ClInclude>
+    <ClInclude Include="..\..\lib\SRC\KPM\FreakMatcher\matchers\feature_matcher.h">
+      <Filter>FreakMatcher\matchers</Filter>
+    </ClInclude>
+    <ClInclude Include="..\..\lib\SRC\KPM\FreakMatcher\matchers\feature_matcher-inline.h">
+      <Filter>FreakMatcher\matchers</Filter>
+    </ClInclude>
+    <ClInclude Include="..\..\lib\SRC\KPM\FreakMatcher\matchers\feature_point.h">
+      <Filter>FreakMatcher\matchers</Filter>
+    </ClInclude>
+    <ClInclude Include="..\..\lib\SRC\KPM\FreakMatcher\matchers\feature_store.h">
+      <Filter>FreakMatcher\matchers</Filter>
+    </ClInclude>
+    <ClInclude Include="..\..\lib\SRC\KPM\FreakMatcher\matchers\freak.h">
+      <Filter>FreakMatcher\matchers</Filter>
+    </ClInclude>
+    <ClInclude Include="..\..\lib\SRC\KPM\FreakMatcher\matchers\freak84-inline.h">
+      <Filter>FreakMatcher\matchers</Filter>
+    </ClInclude>
+    <ClInclude Include="..\..\lib\SRC\KPM\FreakMatcher\matchers\hough_similarity_voting.h">
+      <Filter>FreakMatcher\matchers</Filter>
+    </ClInclude>
+    <ClInclude Include="..\..\lib\SRC\KPM\FreakMatcher\matchers\keyframe.h">
+      <Filter>FreakMatcher\matchers</Filter>
+    </ClInclude>
+    <ClInclude Include="..\..\lib\SRC\KPM\FreakMatcher\matchers\kmedoids.h">
+      <Filter>FreakMatcher\matchers</Filter>
+    </ClInclude>
+    <ClInclude Include="..\..\lib\SRC\KPM\FreakMatcher\matchers\matcher_types.h">
+      <Filter>FreakMatcher\matchers</Filter>
+    </ClInclude>
+    <ClInclude Include="..\..\lib\SRC\KPM\FreakMatcher\matchers\visual_database.h">
+      <Filter>FreakMatcher\matchers</Filter>
+    </ClInclude>
+    <ClInclude Include="..\..\lib\SRC\KPM\FreakMatcher\matchers\visual_database_types.h">
+      <Filter>FreakMatcher\matchers</Filter>
+    </ClInclude>
+    <ClInclude Include="..\..\lib\SRC\KPM\FreakMatcher\matchers\visual_database-inline.h">
+      <Filter>FreakMatcher\matchers</Filter>
+    </ClInclude>
+    <ClInclude Include="..\..\lib\SRC\KPM\FreakMatcher\utils\feature_drawing.h">
+      <Filter>FreakMatcher\utils</Filter>
+    </ClInclude>
+    <ClInclude Include="..\..\lib\SRC\KPM\FreakMatcher\utils\partial_sort.h">
+      <Filter>FreakMatcher\utils</Filter>
+    </ClInclude>
+    <ClInclude Include="..\..\lib\SRC\KPM\FreakMatcher\utils\point.h">
+      <Filter>FreakMatcher\utils</Filter>
+    </ClInclude>
+    <ClInclude Include="..\..\lib\SRC\KPM\FreakMatcher\math\cholesky.h">
+      <Filter>FreakMatcher\math</Filter>
+    </ClInclude>
+    <ClInclude Include="..\..\lib\SRC\KPM\FreakMatcher\math\cholesky_linear_solvers.h">
+      <Filter>FreakMatcher\math</Filter>
+    </ClInclude>
+    <ClInclude Include="..\..\lib\SRC\KPM\FreakMatcher\math\geometry.h">
+      <Filter>FreakMatcher\math</Filter>
+    </ClInclude>
+    <ClInclude Include="..\..\lib\SRC\KPM\FreakMatcher\math\hamming.h">
+      <Filter>FreakMatcher\math</Filter>
+    </ClInclude>
+    <ClInclude Include="..\..\lib\SRC\KPM\FreakMatcher\math\homography.h">
+      <Filter>FreakMatcher\math</Filter>
+    </ClInclude>
+    <ClInclude Include="..\..\lib\SRC\KPM\FreakMatcher\math\indexing.h">
+      <Filter>FreakMatcher\math</Filter>
+    </ClInclude>
+    <ClInclude Include="..\..\lib\SRC\KPM\FreakMatcher\math\linear_algebra.h">
+      <Filter>FreakMatcher\math</Filter>
+    </ClInclude>
+    <ClInclude Include="..\..\lib\SRC\KPM\FreakMatcher\math\linear_solvers.h">
+      <Filter>FreakMatcher\math</Filter>
+    </ClInclude>
+    <ClInclude Include="..\..\lib\SRC\KPM\FreakMatcher\math\math_utils.h">
+      <Filter>FreakMatcher\math</Filter>
+    </ClInclude>
+    <ClInclude Include="..\..\lib\SRC\KPM\FreakMatcher\math\matrix.h">
+      <Filter>FreakMatcher\math</Filter>
+    </ClInclude>
+    <ClInclude Include="..\..\lib\SRC\KPM\FreakMatcher\math\polynomial.h">
+      <Filter>FreakMatcher\math</Filter>
+    </ClInclude>
+    <ClInclude Include="..\..\lib\SRC\KPM\FreakMatcher\math\quaternion.h">
+      <Filter>FreakMatcher\math</Filter>
+    </ClInclude>
+    <ClInclude Include="..\..\lib\SRC\KPM\FreakMatcher\math\rand.h">
+      <Filter>FreakMatcher\math</Filter>
+    </ClInclude>
+    <ClInclude Include="..\..\lib\SRC\KPM\FreakMatcher\math\robustifiers.h">
+      <Filter>FreakMatcher\math</Filter>
+    </ClInclude>
+  </ItemGroup>
+  <ItemGroup>
+    <Filter Include="FreakMatcher">
+      <UniqueIdentifier>{d9a949e0-ec6a-464f-a340-bd52b578adb9}</UniqueIdentifier>
+    </Filter>
+    <Filter Include="FreakMatcher\detectors">
+      <UniqueIdentifier>{2dafb120-2435-4b06-9534-cda6a1c1f63f}</UniqueIdentifier>
+    </Filter>
+    <Filter Include="FreakMatcher\facade">
+      <UniqueIdentifier>{81b2d9d6-b506-4a54-94be-0dc221e80056}</UniqueIdentifier>
+    </Filter>
+    <Filter Include="FreakMatcher\framework">
+      <UniqueIdentifier>{f7204bbb-c698-427d-a65d-079b457c0c34}</UniqueIdentifier>
+    </Filter>
+    <Filter Include="FreakMatcher\homography_estimation">
+      <UniqueIdentifier>{affef859-f4c4-4161-adf4-dbea61262e85}</UniqueIdentifier>
+    </Filter>
+    <Filter Include="FreakMatcher\matchers">
+      <UniqueIdentifier>{829a74e3-e3da-4144-9c7a-a1cd9d6b7b9e}</UniqueIdentifier>
+    </Filter>
+    <Filter Include="FreakMatcher\math">
+      <UniqueIdentifier>{c8cc58cf-9886-4606-ac03-d9e513cb6b19}</UniqueIdentifier>
+    </Filter>
+    <Filter Include="FreakMatcher\Eigen">
+      <UniqueIdentifier>{0f3f1847-93b8-4645-8dfc-366586a70409}</UniqueIdentifier>
+    </Filter>
+    <Filter Include="FreakMatcher\utils">
+      <UniqueIdentifier>{7dafb822-e323-4fc2-b621-bd99a2db3dac}</UniqueIdentifier>
+    </Filter>
+    <Filter Include="FreakMatcher\unsupported">
+      <UniqueIdentifier>{30bf4422-ea66-4d6f-ba87-cae7d8a8c3a6}</UniqueIdentifier>
+    </Filter>
+    <Filter Include="FreakMatcher\unsupported\Eigen">
+      <UniqueIdentifier>{1fb5c959-85b4-4b51-b8bf-c724be2857f7}</UniqueIdentifier>
+    </Filter>
+    <Filter Include="FreakMatcher\Eigen\src">
+      <UniqueIdentifier>{5adf7726-c2c6-43bb-af4e-e514fefd5657}</UniqueIdentifier>
+    </Filter>
+  </ItemGroup>
+  <ItemGroup>
+    <None Include="..\..\lib\SRC\KPM\FreakMatcher\Eigen\Array">
+      <Filter>FreakMatcher\Eigen</Filter>
+    </None>
+    <None Include="..\..\lib\SRC\KPM\FreakMatcher\Eigen\Cholesky">
+      <Filter>FreakMatcher\Eigen</Filter>
+    </None>
+    <None Include="..\..\lib\SRC\KPM\FreakMatcher\Eigen\Core">
+      <Filter>FreakMatcher\Eigen</Filter>
+    </None>
+    <None Include="..\..\lib\SRC\KPM\FreakMatcher\Eigen\Dense">
+      <Filter>FreakMatcher\Eigen</Filter>
+    </None>
+    <None Include="..\..\lib\SRC\KPM\FreakMatcher\Eigen\Eigen">
+      <Filter>FreakMatcher\Eigen</Filter>
+    </None>
+    <None Include="..\..\lib\SRC\KPM\FreakMatcher\Eigen\Eigen2Support">
+      <Filter>FreakMatcher\Eigen</Filter>
+    </None>
+    <None Include="..\..\lib\SRC\KPM\FreakMatcher\Eigen\Eigenvalues">
+      <Filter>FreakMatcher\Eigen</Filter>
+    </None>
+    <None Include="..\..\lib\SRC\KPM\FreakMatcher\Eigen\Geometry">
+      <Filter>FreakMatcher\Eigen</Filter>
+    </None>
+    <None Include="..\..\lib\SRC\KPM\FreakMatcher\Eigen\Householder">
+      <Filter>FreakMatcher\Eigen</Filter>
+    </None>
+    <None Include="..\..\lib\SRC\KPM\FreakMatcher\Eigen\Jacobi">
+      <Filter>FreakMatcher\Eigen</Filter>
+    </None>
+    <None Include="..\..\lib\SRC\KPM\FreakMatcher\Eigen\LeastSquares">
+      <Filter>FreakMatcher\Eigen</Filter>
+    </None>
+    <None Include="..\..\lib\SRC\KPM\FreakMatcher\Eigen\LU">
+      <Filter>FreakMatcher\Eigen</Filter>
+    </None>
+    <None Include="..\..\lib\SRC\KPM\FreakMatcher\Eigen\QR">
+      <Filter>FreakMatcher\Eigen</Filter>
+    </None>
+    <None Include="..\..\lib\SRC\KPM\FreakMatcher\Eigen\QtAlignedMalloc">
+      <Filter>FreakMatcher\Eigen</Filter>
+    </None>
+    <None Include="..\..\lib\SRC\KPM\FreakMatcher\Eigen\Sparse">
+      <Filter>FreakMatcher\Eigen</Filter>
+    </None>
+    <None Include="..\..\lib\SRC\KPM\FreakMatcher\Eigen\StdDeque">
+      <Filter>FreakMatcher\Eigen</Filter>
+    </None>
+    <None Include="..\..\lib\SRC\KPM\FreakMatcher\Eigen\StdList">
+      <Filter>FreakMatcher\Eigen</Filter>
+    </None>
+    <None Include="..\..\lib\SRC\KPM\FreakMatcher\Eigen\StdVector">
+      <Filter>FreakMatcher\Eigen</Filter>
+    </None>
+    <None Include="..\..\lib\SRC\KPM\FreakMatcher\Eigen\SVD">
+      <Filter>FreakMatcher\Eigen</Filter>
+    </None>
+  </ItemGroup>
+</Project>

--- a/lib/SRC/AR/arDetectMarker.c
+++ b/lib/SRC/AR/arDetectMarker.c
@@ -65,7 +65,7 @@ int arDetectMarker( ARHandle *arHandle, ARUint8 *dataPtr )
     int         cid, cdir;
     int         i, j, k;
     int         detectionIsDone = 0;
-	int threshDiff;
+    int         threshDiff;
 
 #if DEBUG_PATT_GETID
 cnt = 0;

--- a/lib/SRC/AR/arDetectMarker.c
+++ b/lib/SRC/AR/arDetectMarker.c
@@ -65,6 +65,7 @@ int arDetectMarker( ARHandle *arHandle, ARUint8 *dataPtr )
     int         cid, cdir;
     int         i, j, k;
     int         detectionIsDone = 0;
+	int threshDiff;
 
 #if DEBUG_PATT_GETID
 cnt = 0;
@@ -109,7 +110,7 @@ cnt = 0;
                 detectionIsDone = 1;
             } else {
                 arHandle->arLabelingThresh = (marker_nums[0] >= marker_nums[1] ? thresholds[0] : thresholds[1]);
-                int threshDiff = arHandle->arLabelingThresh - thresholds[2];
+                threshDiff = arHandle->arLabelingThresh - thresholds[2];
                 if (threshDiff > 0) {
                     arHandle->arLabelingThreshAutoBracketOver = threshDiff;
                     arHandle->arLabelingThreshAutoBracketUnder = 1;

--- a/lib/SRC/AR/arPattLoad.c
+++ b/lib/SRC/AR/arPattLoad.c
@@ -74,7 +74,7 @@ int arPattLoadFromBuffer(ARPattHandle *pattHandle, const char *buffer) {
     if( i == pattHandle->patt_num_max ) return -1;
     patno = i;
 
-    if (!(bufCopy = strdup(buffer))) { // Make a mutable copy.
+    if (!(bufCopy = _strdup(buffer))) { // Make a mutable copy.
         ARLOGe("Error: out of memory.\n");
         return (-1);
     }

--- a/lib/SRC/KPM/FreakMatcher/framework/error.h
+++ b/lib/SRC/KPM/FreakMatcher/framework/error.h
@@ -63,5 +63,7 @@
 #   define DEBUG_BLOCK(X)
 #endif
 
-#define ASSERT_NAN(x) ASSERT(!std::isnan(x), "NaN")
-#define ASSERT_INF(x) ASSERT(!std::isinf(x), "INF")
+#define isnan(x) ((x) != (x))
+#define isinf(x) (!isnan(x) && isnan(x - x))
+#define ASSERT_NAN(x) ASSERT(!isnan(x), "NaN")
+#define ASSERT_INF(x) ASSERT(!isinf(x), "INF")

--- a/lib/SRC/KPM/FreakMatcher/matchers/freak.cpp
+++ b/lib/SRC/KPM/FreakMatcher/matchers/freak.cpp
@@ -74,7 +74,7 @@ void FREAKExtractor::layout84(std::vector<receptor>& receptors,
     const float radius_b = 2;
     
     const float sigma_m = 2;
-    const float sigma_b = std::sqrt(2);
+    const float sigma_b = std::sqrt(2.0f);
     
     float max_radius = -1;
     float max_sigma = -1;


### PR DESCRIPTION
All changes are conveniently split up in different commits, starting with 2(3) trivial commits:
- Fixes to the vs100 files with FREAK dependencies (I figure these are not under active development since 5.2.1), almost identical to the vs120 project except for compiler version. 
- Fixes a bug in arDetectMarker where a variable was declared mid-function and did not compile.

Then 2 separate commits that would need a second opinion:
- Fixed a bug in arPattLoad, strdup is replaced by _strdup. I don't know if this commit will affect other platforms, but I read that _strdup is ISO C++ so it should work?
- Fixed two bugs in FreakMatcher that relied on C++11. std::sqrt, std::isnan and std::isinf.