### PR TITLE
Notes for importing Android projects with IntelliJ IDEA

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -234,3 +234,6 @@ examples/uiControlsWinRT/uiControlsWinRT.Windows/obj/*
 examples/uiControlsWinRT/uiControlsWinRT.WindowsPhone/bin/*
 examples/uiControlsWinRT/uiControlsWinRT.WindowsPhone/obj/*
 
+# IntelliJ IDEA config files
+/EclipseProjects/*/.idea
+/EclipseProjects/*/*.iml

--- a/EclipseProjects/README-IDEA.md
+++ b/EclipseProjects/README-IDEA.md
@@ -1,0 +1,21 @@
+Using with InteliJ IDEA
+=======================
+
+Workarounds
+-----------
+
+IDEA does not properly import Eclipse projects:
+
+* Resources are overwriten, so `pref_entryValues_cameraResolution` and similar resources could not be found. So `res` folder must be copied after import to fix this.
+* To import `ARBaseLib` as module you need to open it with IDEA first.
+* Project dependences are not recognised. You need to manually `Project Settings`->`Modules`->`Add`->`New module`. `ARBaseLib` must be added as a dependency module to your example projects. While importing, use package name `org.artoolkit.ar.base`, so `gen` folder will be correct.
+* Remove `com.android.ide.eclipse.adt.DEPENDENCIES` as you are adding `ARBaseLib` manually. `Add`->`Module Dependency`
+* In `Project Settings`->`Project` ensure, that `Project SDK` is Android not Java deskop.
+* When running, `Target device` should be `USB device`. Examples will not work with emulatror.
+
+Usage
+-----
+
+Launch default Activity.
+Open in computer or print marker from `../doc/patterns/Hiro pattern.pdf` folder.
+Examples will draw 3D cube, when marker is recognised in Android Camera view.


### PR DESCRIPTION
[IntelliJ IDEA](https://www.jetbrains.com/idea/) is very popular among Android (Java) developers.
But there are issues when trying to import Eclipse projects into IDEA.

**Small documentation file could help new-comers to get started faster.**

Alternatives:
* Including `.iml` files does not solve module dependency problem.
* Including `.idea` folder have a lot of local environment settings (so version control would become impossible)
* Having `IdeaProjects/` (as `EclipseProjects`) folder would duplicate source code (again, harder to maintain)