### PR TITLE
adding multimarker tracking options

### DIFF
--- a/include/AR/arMulti.h
+++ b/include/AR/arMulti.h
@@ -88,6 +88,7 @@ typedef struct {
     int                     patt_type;
     ARdouble                cfPattCutoff;
     ARdouble                cfMatrixCutoff;
+    int                     min_submarker;
 } ARMultiMarkerInfoT;
 
 ARMultiMarkerInfoT *arMultiReadConfigFile( const char *filename, ARPattHandle *pattHandle );

--- a/include/ARWrapper/ARToolKitWrapperExportedAPI.h
+++ b/include/ARWrapper/ARToolKitWrapperExportedAPI.h
@@ -474,7 +474,10 @@ extern "C" {
         ARW_MARKER_OPTION_SQUARE_USE_CONT_POSE_ESTIMATION = 4,  ///< bool, true to use continuous pose estimate.
         ARW_MARKER_OPTION_SQUARE_CONFIDENCE = 5,                ///< float, confidence value of most recent marker match
         ARW_MARKER_OPTION_SQUARE_CONFIDENCE_CUTOFF = 6,         ///< float, minimum allowable confidence value used in marker matching.
-        ARW_MARKER_OPTION_NFT_SCALE = 7                         ///< float, scale factor applied to NFT marker size.
+        ARW_MARKER_OPTION_NFT_SCALE = 7,                        ///< float, scale factor applied to NFT marker size.
+        ARW_MARKER_OPTION_MULTI_MIN_SUBMARKERS = 8,             ///< int, minimum number of submarkers for tracking to be valid.
+        ARW_MARKER_OPTION_MULTI_MIN_CONF_MATRIX = 9,            ///< float, minimum confidence value for submarker matrix tracking to be valid.
+        ARW_MARKER_OPTION_MULTI_MIN_CONF_PATTERN = 10,          ///< float, minimum confidence value for submarker pattern tracking to be valid.
     };
     
 	/**

--- a/lib/SRC/ARMulti/arMultiGetTransMat.c
+++ b/lib/SRC/ARMulti/arMultiGetTransMat.c
@@ -137,7 +137,7 @@ static ARdouble  arGetTransMatMultiSquare2(AR3DHandle *handle, ARMarkerInfo *mar
         }
         vnum++;
     }
-    if( vnum == 0 ) { 
+    if( vnum == 0 || vnum < config->min_submarker) { 
         config->prevF = 0;
         return -1;
     }

--- a/lib/SRC/ARMulti/arMultiGetTransMatStereo.c
+++ b/lib/SRC/ARMulti/arMultiGetTransMatStereo.c
@@ -189,7 +189,7 @@ static ARdouble  arGetTransMatMultiSquareStereo2(AR3DStereoHandle *handle,
         vnumR++;
     }
 //ARLOG("vnumL=%d, vnumR=%d\n", vnumL, vnumR);
-    if( vnumL == 0 && vnumR == 0 ) { 
+    if( (vnumL == 0 && vnumR == 0) || (vnumL < config->min_submarker && vnumR < config->min_submarker) ) {
         config->prevF = 0;
 //ARLOG("**** NG.\n");
         return -1;

--- a/lib/SRC/ARWrapper/ARMarkerMulti.cpp
+++ b/lib/SRC/ARWrapper/ARMarkerMulti.cpp
@@ -96,7 +96,7 @@ bool ARMarkerMulti::load(const char *multiConfig, ARPattHandle *arPattHandle)
         patterns[i]->m_matrix[14] = config->marker[i].trans[2][3];
         patterns[i]->m_matrix[15] = _1_0;
 	}
-	
+	config->min_submarker = 0;
     m_loaded = true;
 	return true;
 }

--- a/lib/SRC/ARWrapper/ARToolKitWrapperExportedAPI.cpp
+++ b/lib/SRC/ARWrapper/ARToolKitWrapperExportedAPI.cpp
@@ -727,6 +727,9 @@ EXPORT_API int arwGetMarkerOptionInt(int markerUID, int option)
     }
     
     switch (option) {
+        case ARW_MARKER_OPTION_MULTI_MIN_SUBMARKERS:
+            if (marker->type == ARMarker::MULTI) return ((ARMarkerMulti *)marker)->config->min_submarker;
+            break;
         default:
             gARTK->logv(AR_LOG_LEVEL_ERROR, "arwGetMarkerOptionInt(): Unrecognised option %d.", option);
             break;
@@ -745,6 +748,9 @@ EXPORT_API void arwSetMarkerOptionInt(int markerUID, int option, int value)
     }
 
     switch (option) {
+        case ARW_MARKER_OPTION_MULTI_MIN_SUBMARKERS:
+            if (marker->type == ARMarker::MULTI) ((ARMarkerMulti *)marker)->config->min_submarker = value;
+            break;
         default:
             gARTK->logv(AR_LOG_LEVEL_ERROR, "arwSetMarkerOptionInt(): Unrecognised option %d.", option);
             break;
@@ -784,6 +790,14 @@ EXPORT_API float arwGetMarkerOptionFloat(int markerUID, int option)
             return (NAN);
 #endif
             break;
+        case ARW_MARKER_OPTION_MULTI_MIN_CONF_MATRIX:
+            if (marker->type == ARMarker::MULTI) return (float)((ARMarkerMulti *)marker)->config->cfMatrixCutoff;
+            else return (NAN);
+            break;
+        case ARW_MARKER_OPTION_MULTI_MIN_CONF_PATTERN:
+            if (marker->type == ARMarker::MULTI) return (float)((ARMarkerMulti *)marker)->config->cfPattCutoff;
+            else return (NAN);
+            break;
         default:
             gARTK->logv(AR_LOG_LEVEL_ERROR, "arwGetMarkerOptionFloat(): Unrecognised option %d.", option);
             break;
@@ -815,6 +829,12 @@ EXPORT_API void arwSetMarkerOptionFloat(int markerUID, int option, float value)
 #if HAVE_NFT
             if (marker->type == ARMarker::NFT) ((ARMarkerNFT *)marker)->setNFTScale(value);
 #endif
+            break;
+        case ARW_MARKER_OPTION_MULTI_MIN_CONF_MATRIX:
+            if (marker->type == ARMarker::MULTI) ((ARMarkerMulti *)marker)->config->cfMatrixCutoff = value;
+            break;
+        case ARW_MARKER_OPTION_MULTI_MIN_CONF_PATTERN:
+            if (marker->type == ARMarker::MULTI) ((ARMarkerMulti *)marker)->config->cfPattCutoff = value;
             break;
         default:
             gARTK->logv(AR_LOG_LEVEL_ERROR, "arwSetMarkerOptionFloat(): Unrecognised option %d.", option);


### PR DESCRIPTION
New options exposed in the wrapper for multimarkers.
Can now filter out bad multimarker poses EG when only one marker is visible.
This helps if your use case requires only the good tracking which multimarker tracking affords.