### PR TITLE
bugfix

### DIFF
--- a/lib/SRC/KPM/FreakMatcher/matchers/visual_database.h
+++ b/lib/SRC/KPM/FreakMatcher/matchers/visual_database.h
@@ -174,7 +174,7 @@ namespace vision {
         
         matches_t mMatchedInliers;
         id_t mMatchedId;
-        float mMatchedGeometry[12];
+        float mMatchedGeometry[9];
         
         keyframe_ptr_t mQueryKeyframe;
     


### PR DESCRIPTION
The size of the mMatchedGeometry seems to 9.
And this is not use from other ARToolKit5 codes.
I think that it can be delete from code.