### PR TITLE
Set focus mode in UnityARPlayer

### DIFF
--- a/EclipseProjects/UnityARPlayer/src/org/artoolkit/ar/unity/CameraSurface.java
+++ b/EclipseProjects/UnityARPlayer/src/org/artoolkit/ar/unity/CameraSurface.java
@@ -141,13 +141,20 @@ public class CameraSurface extends SurfaceView implements SurfaceHolder.Callback
     	if (camera != null) {
 
     		String camResolution = PreferenceManager.getDefaultSharedPreferences(getContext()).getString("pref_cameraResolution", "320x240");
-            String[] dims = camResolution.split("x", 2);
+    		String[] dims = camResolution.split("x", 2);
+    		String camFocusMode = PreferenceManager.getDefaultSharedPreferences(getContext()).getString("pref_cameraFocusMode", "auto");
+    		if (camFocusMode.toLowerCase().equals("fixed")) {
+    			camFocusMode = Camera.Parameters.FOCUS_MODE_FIXED;
+    		} else {
+    			camFocusMode = Camera.Parameters.FOCUS_MODE_CONTINUOUS_PICTURE;
+    		}
+            
             Camera.Parameters parameters = camera.getParameters();
             parameters.setPreviewSize(Integer.parseInt(dims[0]), Integer.parseInt(dims[1]));
-            parameters.setPreviewFrameRate(30);
-            if (parameters.getSupportedFocusModes().contains(Camera.Parameters.FOCUS_MODE_CONTINUOUS_PICTURE)) {
-            	parameters.setFocusMode(Camera.Parameters.FOCUS_MODE_CONTINUOUS_PICTURE);
+            if (parameters.getSupportedFocusModes().contains(camFocusMode)) {
+            	parameters.setFocusMode(camFocusMode);
             }
+            parameters.setPreviewFrameRate(30);
             camera.setParameters(parameters);        
             
             parameters = camera.getParameters();

--- a/EclipseProjects/UnityARPlayer/src/org/artoolkit/ar/unity/CameraSurface.java
+++ b/EclipseProjects/UnityARPlayer/src/org/artoolkit/ar/unity/CameraSurface.java
@@ -145,6 +145,9 @@ public class CameraSurface extends SurfaceView implements SurfaceHolder.Callback
             Camera.Parameters parameters = camera.getParameters();
             parameters.setPreviewSize(Integer.parseInt(dims[0]), Integer.parseInt(dims[1]));
             parameters.setPreviewFrameRate(30);
+            if (parameters.getSupportedFocusModes().contains(Camera.Parameters.FOCUS_MODE_CONTINUOUS_PICTURE)) {
+            	parameters.setFocusMode(Camera.Parameters.FOCUS_MODE_CONTINUOUS_PICTURE);
+            }
             camera.setParameters(parameters);        
             
             parameters = camera.getParameters();


### PR DESCRIPTION
Can be configured from preference: "auto" = FOCUS_MODE_CONTINUOUS_PICTURE, "fixed" = FOCUS_MODE_FIXED. Default is "auto". Check if the mode is supported before setting.
Related to: https://github.com/artoolkit/arunity5/issues/37