### PR TITLE
Optimize for around robust_homography.h

### DIFF
--- a/lib/SRC/KPM/FreakMatcher/homography_estimation/robust_homography.h
+++ b/lib/SRC/KPM/FreakMatcher/homography_estimation/robust_homography.h
@@ -108,7 +108,6 @@ namespace vision {
                                     int max_trials = HOMOGRAPHY_DEFAULT_MAX_TRIALS,
                                     int chunk_size = HOMOGRAPHY_DEFAULT_CHUNK_SIZE) {
         int* hyp_perm;
-        int* point_perm;
         T one_over_scale2;
         T min_cost;
         int num_hypotheses, num_hypotheses_remaining, min_index;
@@ -118,7 +117,7 @@ namespace vision {
         int sample_size = 4;
         
         ASSERT(hyp.size() >= 9*max_num_hypotheses, "hyp vector should be of size 9*max_num_hypotheses");
-        ASSERT(tmp_i.size() >= 2*num_points, "tmp_i vector should be of size 2*num_points");
+        ASSERT(tmp_i.size() >= num_points, "tmp_i vector should be of size num_points");
         ASSERT(hyp_costs.size() >= max_num_hypotheses, "hyp_costs vector should be of size max_num_hypotheses");
         
         // We need at least SAMPLE_SIZE points to sample from
@@ -129,20 +128,17 @@ namespace vision {
         seed = 1234;
         
         hyp_perm = &tmp_i[0];
-        point_perm = &tmp_i[num_points];
-        
+
         one_over_scale2 = 1/sqr(scale);
         chunk_size = min2(chunk_size, num_points);
         next_chunk = 0;
         
-        // Fill two arrays from [0,num_points)
+        // Fill arrays from [0)
         SequentialVector(hyp_perm, num_points, 0);
-        SequentialVector(point_perm, num_points, 0);
-        
+
         // Shuffle the indices
         ArrayShuffle(hyp_perm, num_points, num_points, seed);
-        ArrayShuffle(point_perm, num_points, num_points, seed);
-        
+
         // Compute a set of hypotheses
         for(trial = 0, num_hypotheses = 0;
             trial < max_trials && num_hypotheses < max_num_hypotheses;
@@ -215,8 +211,8 @@ namespace vision {
                 const T* H_cur = &hyp[hyp_costs[j].second*9];
                 for(int k = i; k < this_chunk_end; k++) {
                     hyp_costs[j].first += CauchyProjectiveReprojectionCost(H_cur,
-                                                                           &p[point_perm[k]<<1],
-                                                                           &q[point_perm[k]<<1],
+                                                                           &p[hyp_perm[k]<<1],
+                                                                           &q[hyp_perm[k]<<1],
                                                                            one_over_scale2);
                 }
             }

--- a/lib/SRC/KPM/FreakMatcher/homography_estimation/robust_homography.h
+++ b/lib/SRC/KPM/FreakMatcher/homography_estimation/robust_homography.h
@@ -101,7 +101,7 @@ namespace vision {
                                     const T* test_points,
                                     int num_test_points,
                                     std::vector<T> &hyp /* 9*max_num_hypotheses */,
-                                    std::vector<int> &tmp_i /* 2*num_points */,
+                                    std::vector<int> &tmp_i /* num_points */,
                                     std::vector< std::pair<T, int> > &hyp_costs /* max_num_hypotheses */,
                                     T scale = HOMOGRAPHY_DEFAULT_CAUCHY_SCALE,
                                     int max_num_hypotheses = HOMOGRAPHY_DEFAULT_NUM_HYPOTHESES,

--- a/lib/SRC/KPM/FreakMatcher/homography_estimation/robust_homography.h
+++ b/lib/SRC/KPM/FreakMatcher/homography_estimation/robust_homography.h
@@ -633,7 +633,7 @@ namespace vision {
     
     template<typename T>
     bool RobustHomography<T>::find(float H[9], const T* p, const T* q, int num_points) {
-        mTmpi.resize(2*num_points);
+        mTmpi.resize(num_points);
         if(!PreemptiveRobustHomography<T>(H,
                                           p,
                                           q,
@@ -655,7 +655,7 @@ namespace vision {
     
     template<typename T>
     bool RobustHomography<T>::find(float H[9], const T* p, const T* q, int num_points, const T* test_points, int num_test_points) {
-        mTmpi.resize(2*num_points);
+        mTmpi.resize(num_points);
         return PreemptiveRobustHomography<T>(H,
                                              p,
                                              q,

--- a/lib/SRC/KPM/FreakMatcher/matchers/visual_database-inline.h
+++ b/lib/SRC/KPM/FreakMatcher/matchers/visual_database-inline.h
@@ -240,7 +240,6 @@ namespace vision {
                                        query_points,
                                        ref_points,
                                        hough_matches,
-                                       mHomographyInlierThreshold,
                                        mRobustHomography,
                                        it->second->width(),
                                        it->second->height())) {
@@ -308,7 +307,6 @@ namespace vision {
                                        query_points,
                                        ref_points,
                                        hough_matches,
-                                       mHomographyInlierThreshold,
                                        mRobustHomography,
                                        it->second->width(),
                                        it->second->height())) {

--- a/lib/SRC/KPM/FreakMatcher/matchers/visual_database.h
+++ b/lib/SRC/KPM/FreakMatcher/matchers/visual_database.h
@@ -360,7 +360,6 @@ namespace vision {
                                    const std::vector<FeaturePoint>& p1,
                                    const std::vector<FeaturePoint>& p2,
                                    const matches_t& matches,
-                                   float threshold,
                                    RobustHomography<float>& estimator,
                                    int refWidth,
                                    int refHeight) {


### PR DESCRIPTION
1.Reduce working memory on robust_homography.h :: PreemptiveRobustHomography
2.Remove unused argument from EstimateHomography function.