### PR TITLE
marker corners can be queried after detection with the Android api

### DIFF
--- a/AndroidStudioProjects/ARBaseLibProj/aRBaseLib/src/main/java/org/artoolkit/ar/base/ARToolKit.java
+++ b/AndroidStudioProjects/ARBaseLibProj/aRBaseLib/src/main/java/org/artoolkit/ar/base/ARToolKit.java
@@ -323,6 +323,18 @@ public class ARToolKit {
         if (!initedNative) return null;
         return NativeInterface.arwQueryMarkerTransformation(markerUID);
     }
+    
+    /**
+     * Retrieves the corner points for the specified marker
+     *
+     * @param markerUID The unique identifier (UID) of the marker to check
+     * @return A float array of size 8 containing the corner points starting at top left (x,y) top right, bottom right, bottom left.
+     *
+     */
+    public float[] arwQueryMarkerCornerPoints(int markerUID) {
+        if (!initedNative) return null;
+        return NativeInterface.arwQueryMarkerCornerPoints(markerUID);
+    }
 
     /**
      * Returns true when video and marker detection are running.

--- a/AndroidStudioProjects/ARBaseLibProj/aRBaseLib/src/main/java/org/artoolkit/ar/base/NativeInterface.java
+++ b/AndroidStudioProjects/ARBaseLibProj/aRBaseLib/src/main/java/org/artoolkit/ar/base/NativeInterface.java
@@ -285,6 +285,15 @@ public class NativeInterface {
     public static native float[] arwQueryMarkerTransformation(int markerUID);
 
     /**
+     * Retrieves the corner points for the specified marker
+     *
+     * @param markerUID The unique identifier (UID) of the marker to check
+     * @return A float array of size 8 containing the corner points starting at top left (x,y) top right, bottom right, bottom left.
+     *
+     */
+    public static native float[] arwQueryMarkerCornerPoints(int markerUID);
+
+    /**
      * Retrieves the transformation matrix for the specified marker
      *
      * @param markerUID The unique identifier (UID) of the marker to check

--- a/include/ARWrapper/ARMarker.h
+++ b/include/ARWrapper/ARMarker.h
@@ -96,7 +96,8 @@ public:
     // Output.
 	ARdouble transformationMatrix[16];		///< Transformation suitable for use in OpenGL
 	ARdouble transformationMatrixR[16];		///< Transformation suitable for use in OpenGL
-	
+    float cornerPoints[8];                  ///< Corner points of detected marker from top left clockwise.
+
 	int patternCount;						///< Number of patterns in this marker (1 for single)
 	ARPattern** patterns;					///< Array of pointers to patterns
 

--- a/lib/SRC/ARWrapper/ARMarkerSquare.cpp
+++ b/lib/SRC/ARWrapper/ARMarkerSquare.cpp
@@ -221,6 +221,10 @@ bool ARMarkerSquare::updateWithDetectedMarkers(ARMarkerInfo* markerInfo, int mar
         if (k != -1) {
             visible = true;
             m_cf = markerInfo[k].cf;
+            for (int c = 0; c < 4; c++) {
+                cornerPoints[c*2] = markerInfo[k].vertex[c][0];
+                cornerPoints[c*2 + 1] = markerInfo[k].vertex[c][1];
+            }
             // If the model is visible, update its transformation matrix
 			if (visiblePrev && useContPoseEstimation) {
 				// If the marker was visible last time, use "cont" version of arGetTransMatSquare

--- a/lib/SRC/ARWrapper/ARToolKitWrapperExportedAPI.cpp
+++ b/lib/SRC/ARWrapper/ARToolKitWrapperExportedAPI.cpp
@@ -571,6 +571,19 @@ EXPORT_API bool arwQueryMarkerVisibility(int markerUID)
     return marker->visible;
 }
 
+EXPORT_API bool arwQueryMarkerCornerPoints(int markerUID, float points[8])
+{
+    ARMarker *marker;
+
+    if (!gARTK) return false;
+    if (!(marker = gARTK->findMarker(markerUID))) {
+        gARTK->logv(AR_LOG_LEVEL_ERROR, "arwQueryMarkerCornerPoints(): Couldn't locate marker with UID %d.", markerUID);
+        return false;
+    }
+    for (int i = 0; i < 8; i++) points[i] = (float)marker->cornerPoints[i];
+    return marker->visible;
+}
+
 EXPORT_API bool arwQueryMarkerTransformation(int markerUID, float matrix[16])
 {
     ARMarker *marker;
@@ -903,6 +916,7 @@ extern "C" {
 	JNIEXPORT jboolean JNICALL JNIFUNCTION(arwRemoveMarker(JNIEnv *env, jobject obj, jint markerUID));
 	JNIEXPORT jint JNICALL JNIFUNCTION(arwRemoveAllMarkers(JNIEnv *env, jobject obj));
 	JNIEXPORT jboolean JNICALL JNIFUNCTION(arwQueryMarkerVisibility(JNIEnv *env, jobject obj, jint markerUID));
+    JNIEXPORT jfloatArray JNICALL JNIFUNCTION(arwQueryMarkerCornerPoints(JNIEnv *env, jobject obj, jint markerUID));
 	JNIEXPORT jfloatArray JNICALL JNIFUNCTION(arwQueryMarkerTransformation(JNIEnv *env, jobject obj, jint markerUID));
 	JNIEXPORT jboolean JNICALL JNIFUNCTION(arwQueryMarkerTransformationStereo(JNIEnv *env, jobject obj, jint markerUID, jfloatArray matrixL, jfloatArray matrixR));
 	JNIEXPORT jint JNICALL JNIFUNCTION(arwGetMarkerPatternCount(JNIEnv *env, jobject obj, int markerUID));
@@ -1126,7 +1140,15 @@ JNIEXPORT jboolean JNICALL JNIFUNCTION(arwQueryMarkerVisibility(JNIEnv *env, job
 	return arwQueryMarkerVisibility(markerUID);
 }
 
-JNIEXPORT jfloatArray JNICALL JNIFUNCTION(arwQueryMarkerTransformation(JNIEnv *env, jobject obj, jint markerUID)) 
+JNIEXPORT jfloatArray JNICALL JNIFUNCTION(arwQueryMarkerCornerPoints(JNIEnv *env, jobject obj, jint markerUID))
+{
+    float corners[8];
+
+    if (arwQueryMarkerCornerPoints(markerUID, corners)) return glArrayToJava(env, corners, 8);
+    return NULL;
+}
+
+JNIEXPORT jfloatArray JNICALL JNIFUNCTION(arwQueryMarkerTransformation(JNIEnv *env, jobject obj, jint markerUID))
 {
 	float trans[16];
     


### PR DESCRIPTION
Allow accessing the detected marker corners with the Android api. See forum discussion as well:

https://artoolkit.org/community/forums/viewtopic.php?f=26&t=16099#p20620