### PR TITLE
Fix potential crash caused by AndroidVideoSource.

### DIFF
--- a/lib/SRC/ARWrapper/AndroidVideoSource.cpp
+++ b/lib/SRC/ARWrapper/AndroidVideoSource.cpp
@@ -248,6 +248,7 @@ bail:
     free(incomingFrameRawBuffer);
     incomingFrameRawBuffer = NULL;
     incomingFrameRawBufferSize = 0;
+    frameBuffer = NULL;
     
     deviceState = DEVICE_OPEN;
     return false;
@@ -303,6 +304,7 @@ bool AndroidVideoSource::close() {
     newFrameArrived = false;
     ar2VideoClose(gVid);
     gVid = NULL;
+    frameBuffer = NULL;
 
 	deviceState = DEVICE_CLOSED;
 	ARController::logv(AR_LOG_LEVEL_INFO, "Android Video Source closed.");


### PR DESCRIPTION
AndroidVideoSource will clear the local frame buffer (`localFrameBuffer`) as needed
but neglected to clear the `frameBuffer` that is used by the underlying VideoSource which,
under certain circumstances, could lead to a segmentation fault.