### PR TITLE
Memory Leak correction arPattCreateHandle.c

### DIFF
--- a/lib/SRC/AR/arPattCreateHandle.c
+++ b/lib/SRC/AR/arPattCreateHandle.c
@@ -90,13 +90,20 @@ int arPattDeleteHandle(ARPattHandle *pattHandle)
 	
 	if (pattHandle == NULL) return (-1);
 	
-    for (i = 0; i < pattHandle->patt_num_max; i++) {
+    	for (i = 0; i < pattHandle->patt_num_max; i++) {
 		if (pattHandle->pattf[i] != 0) arPattFree(pattHandle, i);
-        for (j = 0; j < 4; j++) {
-            free(pattHandle->patt[i*4 + j]);
-            free(pattHandle->pattBW[i*4 + j]);
-        }
+        	for (j = 0; j < 4; j++) {
+            		free(pattHandle->patt[i*4 + j]);
+            		free(pattHandle->pattBW[i*4 + j]);
+		}
 	}
+	
+	free(pattHandle->patt);
+	free(pattHandle->pattBW);
+	free(pattHandle->pattf);
+	free(pattHandle->pattpow);
+	free(pattHandle->pattpowBW);
+	
 	free(pattHandle);
 	pattHandle = NULL;
 	


### PR DESCRIPTION
unfreed memory at "arPattDeleteHandle". 
At least one more modification should be done. When the variable pattHandle is set to NULL, it only is at the scope of the function "arPattDeleteHandle". The "pattHandle" that is passed by argument to the function "arPattDeleteHandle" would not change it's value to NULL. In order to do that we should change the function to

```
int arPattDeleteHandle(ARPattHandle **_pattHandle)
{
    int i, j;
    ARPattHandle* pattHandle = *_pattHandle;

    if (pattHandle == NULL) return (-1);

    for (i = 0; i < pattHandle->patt_num_max; i++) {
        if (pattHandle->pattf[i] != 0) arPattFree(pattHandle, i);
        for (j = 0; j < 4; j++) {
            free(pattHandle->patt[i*4 + j]);
            free(pattHandle->pattBW[i*4 + j]);
        }
    }
    free(pattHandle->patt);
    free(pattHandle->pattBW);
    free(pattHandle->pattf);
    free(pattHandle->pattpow);
    free(pattHandle->pattpowBW);

    free(pattHandle);
    *_pattHandle = NULL;

    return (0);
}
```
