### PR TITLE
Bug fix in nft marker loading when nativeStop is called, not safe operation in nftBook.cpp

### DIFF
--- a/AndroidStudioProjects/nftBookProj/nftBook/src/main/jni/nftBook.cpp
+++ b/AndroidStudioProjects/nftBookProj/nftBook/src/main/jni/nftBook.cpp
@@ -276,6 +276,13 @@ JNIEXPORT jboolean JNICALL JNIFUNCTION_NATIVE(nativeStop(JNIEnv* env, jobject ob
     
 	// Can't call arglCleanup() or VirtualEnvironmentFinal() here, because nativeStop is not called on rendering thread.
 
+	//NFT Loading cleanup, fixing bug when loading large resources file.
+    if(nftDataLoadingThreadHandle){
+        //TODO: Send a signal saying to the user to wait resources are being cleaned up.
+        threadEndWait(nftDataLoadingThreadHandle);
+        threadWaitQuit(nftDataLoadingThreadHandle);
+        threadFree(&nftDataLoadingThreadHandle); // Clean up.
+    }
     // NFT cleanup.
     if (trackingThreadHandle) {
 #ifdef DEBUG


### PR DESCRIPTION
While loading large resources file, lets say 20 nft markers and the user hit back button, it caused app crash unexpectedly. Because of the index access violation in kpmSetRefDataSet. When cleaning resources, markers are still been loaded in other thread.