### PR TITLE
Add locks and ping-pong buffer to ARWrapper to eliminate texture tearing

### DIFF
--- a/android/build.sh
+++ b/android/build.sh
@@ -64,11 +64,13 @@ else #Checking for Windows in a non-cygwin dependent way.
     WinsOS=
     if [[ $OS ]]; then
         WinsVerNum=${OS##*-}
-        if [[ $WinsVerNum = "10.0" || $WinsVerNum = "6.3" ]]; then
+        if [[ $WinsVerNum = "10.0" || $WinsVerNum = "6.3" || $WinsVerNum = "6.1" ]]; then
             if [[ $WinsVerNum = "10.0" ]]; then
                 WinsOS="Wins10"
-            else
+            elif [[ $WinsVerNum = "6.3" ]]; then
                 WinsOS="Wins8.1"
+            else
+                WinsOS="Wins7"
             fi
             echo Building on Microsoft ${WinsOS} Desktop \(${ARCH}\)
             export HOST_OS="windows"

--- a/include/ARWrapper/AndroidVideoSource.h
+++ b/include/ARWrapper/AndroidVideoSource.h
@@ -56,9 +56,9 @@ private:
 	bool newFrameArrived;
     AR2VideoBufferT *localFrameBuffer;
     size_t incomingFrameRawBufferSize;
-    unsigned char *incomingFrameRawBuffer;
+    unsigned char *incomingFrameRawBuffer[2];
     size_t convertedFrameRawBufferSize;
-    ARUint8 *convertedFrameRawBuffer;
+    ARUint8 *convertedFrameRawBuffer[2];
     
     static void getVideoReadyAndroidCparamCallback(const ARParam *cparam_p, void *userdata);
     bool getVideoReadyAndroid2(const ARParam *cparam_p);

--- a/lib/SRC/ARWrapper/AndroidVideoSource.cpp
+++ b/lib/SRC/ARWrapper/AndroidVideoSource.cpp
@@ -272,12 +272,13 @@ void AndroidVideoSource::acceptImage(JNIEnv* env, jbyteArray pinArray) {
 	
     //ARController::logv("AndroidVideoSource::acceptImage()");
 	if (deviceState == DEVICE_RUNNING) {
-        
+        lockFrameBuffer();
         env->GetByteArrayRegion(pinArray, 0, incomingFrameRawBufferSize, (jbyte *)incomingFrameRawBuffer);
         
         if (pixelFormat == AR_PIXEL_FORMAT_RGBA) {
             color_convert_common((unsigned char *)incomingFrameRawBuffer, (unsigned char *)(incomingFrameRawBuffer + videoWidth * videoHeight), videoWidth, videoHeight, convertedFrameRawBuffer);
         }
+        unlockFrameBuffer();
 		frameStamp++;
 		newFrameArrived = true;
     }


### PR DESCRIPTION
Fixes https://github.com/artoolkit/artoolkit5/issues/231.