### PR TITLE
Add nftSimpleProj cmake && lldb debug support.

### DIFF
--- a/AndroidStudioProjects/nftSimpleProj/build.gradle
+++ b/AndroidStudioProjects/nftSimpleProj/build.gradle
@@ -6,7 +6,7 @@ buildscript {
     }
 
     dependencies {
-        classpath 'com.android.tools.build:gradle:2.2.1'
+        classpath 'com.android.tools.build:gradle:2.3.0'
 
         // NOTE: Do not place your application dependencies here; they belong
         // in the individual module build.gradle files

--- a/AndroidStudioProjects/nftSimpleProj/nftSimple/build.gradle
+++ b/AndroidStudioProjects/nftSimpleProj/nftSimple/build.gradle
@@ -2,7 +2,7 @@ apply plugin: 'com.android.application'
 
 android {
     compileSdkVersion = 24
-    buildToolsVersion = "24.0.3"
+    buildToolsVersion = "25.0.2"
 
     defaultConfig {
         applicationId = "org.artoolkit.ar.samples.NftSimple"
@@ -19,13 +19,26 @@ android {
         }
 
         ndk {
-            moduleName = "NftSimple"
+            abiFilters 'armeabi-v7a' //'x86', 'x86_64', 'armeabi', 'armeabi-v7a', 'arm64-v8a'
+        }
+
+        externalNativeBuild {
+            cmake {
+                arguments '-DANDROID_PLATFORM=android-14',
+                        '-DANDROID_TOOLCHAIN=clang', '-DANDROID_STL=c++_shared'
+            }
         }
     }
 
     sourceSets.main {
         jni.srcDirs = []
         jniLibs.srcDir 'src/main/libs'
+    }
+
+    externalNativeBuild {
+        cmake {
+            path 'src/main/jni/CMakeLists.txt'
+        }
     }
 }
 

--- a/AndroidStudioProjects/nftSimpleProj/nftSimple/src/main/jni/CMakeLists.txt
+++ b/AndroidStudioProjects/nftSimpleProj/nftSimple/src/main/jni/CMakeLists.txt
@@ -1,0 +1,68 @@
+#
+# Copyright (C) The Android Open Source Project
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+cmake_minimum_required(VERSION 3.4.1)
+
+include(AndroidNdkModules)
+android_ndk_import_module_cpufeatures()
+
+# configure import libs
+set(AR_ROOT_DIR ${CMAKE_SOURCE_DIR}/../../../../../..)
+
+# add static librarys
+add_subdirectory(${AR_ROOT_DIR}/lib/SRC/AR ar)
+add_subdirectory(${AR_ROOT_DIR}/lib/SRC/AR2 ar2)
+add_subdirectory(${AR_ROOT_DIR}/lib/SRC/ARICP aricp)
+add_subdirectory(${AR_ROOT_DIR}/lib/SRC/Gl argsub_es)
+add_subdirectory(${AR_ROOT_DIR}/lib/SRC/KPM kpm)
+add_subdirectory(${AR_ROOT_DIR}/lib/SRC/Util util)
+add_subdirectory(${AR_ROOT_DIR}/lib/SRC/Eden eden)
+add_subdirectory(${AR_ROOT_DIR}/lib/SRC/Video arvideo)
+
+# add jpeg static library
+add_library(jpeg STATIC IMPORTED)
+set_target_properties(jpeg PROPERTIES IMPORTED_LOCATION
+    ${AR_ROOT_DIR}/android/obj/local/${ANDROID_ABI}/libjpeg.a)
+
+# add curl static library
+add_library(curl STATIC IMPORTED)
+set_target_properties(curl PROPERTIES IMPORTED_LOCATION
+    ${AR_ROOT_DIR}/android/jni/curl/libs/${ANDROID_ABI}/libcurl.a)
+
+# build application's shared lib
+set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -std=gnu++11 -Wall -frtti -fexceptions -DDEBUG")
+
+add_library(nftSimpleNative SHARED
+            ARMarkerNFT.c trackingSub.c nftSimple.cpp)
+
+target_include_directories(nftSimpleNative PRIVATE
+                           ${AR_ROOT_DIR}/include)
+
+target_link_libraries(nftSimpleNative
+                      ar2
+                      argsub_es
+                      kpm
+                      util
+                      eden
+                      ar
+                      aricp
+                      arvideo
+                      jpeg
+                      curl
+                      cpufeatures
+                      log
+                      GLESv1_CM
+                      z)

--- a/lib/SRC/AR/CMakeLists.txt
+++ b/lib/SRC/AR/CMakeLists.txt
@@ -1,0 +1,12 @@
+set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -std=gnu++11 -Wall -fexceptions -frtti -DHAVE_ARM_NEON=1")
+
+file(GLOB AR_SRC_LIST *.c)
+file(GLOB ARSUB_SRC_LIST arLabelingSub/*.c)
+
+add_library(ar STATIC
+		${AR_SRC_LIST}
+		${ARSUB_SRC_LIST})
+
+target_include_directories(ar PRIVATE
+                           ${AR_ROOT_DIR}/include
+                           ${AR_ROOT_DIR}/include/android)

--- a/lib/SRC/AR2/CMakeLists.txt
+++ b/lib/SRC/AR2/CMakeLists.txt
@@ -1,0 +1,10 @@
+set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -std=gnu++11 -Wall -fexceptions -frtti")
+
+file(GLOB AR2_SRC_LIST *.c)
+
+add_library(ar2 STATIC
+		${AR2_SRC_LIST})
+
+target_include_directories(ar2 PRIVATE
+                           ${AR_ROOT_DIR}/include
+                           ${AR_ROOT_DIR}/include/android)

--- a/lib/SRC/ARICP/CMakeLists.txt
+++ b/lib/SRC/ARICP/CMakeLists.txt
@@ -1,0 +1,10 @@
+set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -std=gnu++11 -Wall -fexceptions -frtti")
+
+file(GLOB ARICP_SRC_LIST *.c)
+
+add_library(aricp STATIC
+		${ARICP_SRC_LIST})
+
+target_include_directories(aricp PRIVATE
+                           ${AR_ROOT_DIR}/include
+                           ${AR_ROOT_DIR}/include/android)

--- a/lib/SRC/Eden/CMakeLists.txt
+++ b/lib/SRC/Eden/CMakeLists.txt
@@ -1,0 +1,14 @@
+set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -std=gnu++11 -Wall -fexceptions -frtti")
+
+file(GLOB EDEN_SRC_LIST *.c)
+file(GLOB EDEN_CPP_LIST *.cpp)
+file(GLOB EDEN_GLUT_LIST gluttext/*.c)
+
+add_library(eden STATIC
+		${EDEN_SRC_LIST}
+		${EDEN_GLUT_LIST}
+		${EDEN_CPP_LIST})
+
+target_include_directories(eden PRIVATE
+                           ${AR_ROOT_DIR}/include
+                           ${AR_ROOT_DIR}/include/android)

--- a/lib/SRC/Gl/CMakeLists.txt
+++ b/lib/SRC/Gl/CMakeLists.txt
@@ -1,0 +1,10 @@
+set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -std=gnu++11 -Wall -fexceptions -frtti -DHAVE_ARM_NEON=1")
+
+add_library(argsub_es STATIC
+		gsub_es.c
+		glStateCache.c
+		gsub_mtx.c)
+
+target_include_directories(argsub_es PRIVATE
+                           ${AR_ROOT_DIR}/include
+                           ${AR_ROOT_DIR}/include/android)

--- a/lib/SRC/KPM/CMakeLists.txt
+++ b/lib/SRC/KPM/CMakeLists.txt
@@ -1,0 +1,26 @@
+set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -std=gnu++11 -Wall -fexceptions -frtti -Wno-extern-c-compat -Wno-null-conversion")
+
+file(GLOB KPM_SRC_LIST *.c)
+file(GLOB KPM_CPP_LIST *.cpp)
+
+add_library(kpm STATIC
+		${KPM_SRC_LIST}
+		${KPM_CPP_LIST}
+		FreakMatcher/detectors/DoG_scale_invariant_detector.cpp
+		FreakMatcher/detectors/gaussian_scale_space_pyramid.cpp
+		FreakMatcher/detectors/gradients.cpp
+		FreakMatcher/detectors/harris.cpp
+		FreakMatcher/detectors/orientation_assignment.cpp
+		FreakMatcher/detectors/pyramid.cpp
+		FreakMatcher/facade/visual_database_facade.cpp
+		FreakMatcher/framework/date_time.cpp
+		FreakMatcher/framework/image.cpp
+		FreakMatcher/framework/logger.cpp
+		FreakMatcher/framework/timers.cpp
+		FreakMatcher/matchers/freak.cpp
+		FreakMatcher/matchers/hough_similarity_voting.cpp)
+
+target_include_directories(kpm PRIVATE
+                           ${AR_ROOT_DIR}/include
+                           ${AR_ROOT_DIR}/include/android
+                           ${AR_ROOT_DIR}/lib/SRC/KPM/FreakMatcher)

--- a/lib/SRC/Util/CMakeLists.txt
+++ b/lib/SRC/Util/CMakeLists.txt
@@ -1,0 +1,10 @@
+set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -std=gnu++11 -Wall -fexceptions -frtti")
+
+file(GLOB UTIL_SRC_LIST *.c)
+
+add_library(util STATIC
+		${UTIL_SRC_LIST})
+
+target_include_directories(util PRIVATE
+                           ${AR_ROOT_DIR}/include
+                           ${AR_ROOT_DIR}/include/android)

--- a/lib/SRC/Video/CMakeLists.txt
+++ b/lib/SRC/Video/CMakeLists.txt
@@ -1,0 +1,15 @@
+set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -std=gnu++11 -Wall -fexceptions -frtti -DHAVE_ARM_NEON=1")
+
+file(GLOB VIDEO_SRC_LIST *.c)
+
+add_library(arvideo STATIC
+		${VIDEO_SRC_LIST}
+		${AR_ROOT_DIR}/lib/SRC/VideoAndroid/videoAndroid.c
+		${AR_ROOT_DIR}/lib/SRC/VideoAndroid/sqlite3.c
+		${AR_ROOT_DIR}/lib/SRC/VideoDummy/videoDummy.c
+		${AR_ROOT_DIR}/lib/SRC/VideoImage/videoImage.c)
+
+target_include_directories(arvideo PRIVATE
+                           ${AR_ROOT_DIR}/include
+                           ${AR_ROOT_DIR}/include/android
+                           ${AR_ROOT_DIR}/android/jni/curl/include)


### PR DESCRIPTION
1. Build shared library use gradle & cmake, don't need call ndk-build;
2. Upgrade AS's gradle plugin to ver 2.3.0+, grade ver >=3.3.
Now you can debug java & native code from AS!