### PR TITLE
Add pixel format conversion framework V4L2 backend

### DIFF
--- a/include/AR/sys/videoLinuxV4L2.h
+++ b/include/AR/sys/videoLinuxV4L2.h
@@ -100,6 +100,8 @@ typedef struct {
     int                    video_cont_num;
     ARUint8                *videoBuffer;
 
+    int (*toArPixelFormat)(int width, int height, const void *src, void *dst);
+
     pthread_t              capture;
     AR2VideoBufferV4L2T    buffer;
     

--- a/lib/SRC/VideoLinuxV4L2/videoV4L2.c
+++ b/lib/SRC/VideoLinuxV4L2/videoV4L2.c
@@ -180,7 +180,7 @@ static int bgr24ToBgr24(const int width, const int height,
 }
 
 // destination format AR_PIX_FORMAT_BGRA
-static void yuyvToBgr32(void const *src, int width, int height, void *dst)
+static int yuyvToBgr32(int width, int height, const void *src, void *dst)
 {
     unsigned char *yuyv_image = (unsigned char*) src;
     unsigned char *rgb_image = (unsigned char*) dst;
@@ -233,11 +233,12 @@ static void yuyvToBgr32(void const *src, int width, int height, void *dst)
         }
         
     }
-    
+
+    return 0;
 }
 
 // destination format AR_PIX_FORMAT_BGR
-static void yuyvToBgr24(void const *src, int width, int height, void *dst)
+static int yuyvToBgr24(int width, int height, const void *src, void *dst)
 {
     unsigned char *yuyv_image = (unsigned char*) src;
     unsigned char *rgb_image = (unsigned char*) dst;
@@ -287,6 +288,8 @@ static void yuyvToBgr24(void const *src, int width, int height, void *dst)
         }
         
     }
+
+    return 0;
 }
 
 /*-------------------------------------------*/


### PR DESCRIPTION
`ar2VideoOpenV4L2()` assigns a conversion function to `vid->toArPixelFormat`. If a conversion is not implemented, the function bails. `ar2VideoGetImageV4L2()` calls `vid->toArPixelFormat` to convert the incoming image to ARToolkit's internal pixel format.