### PR TITLE
Const char * fix for clang 9.0.0

### DIFF
--- a/lib/SRC/AR/arUtil.c
+++ b/lib/SRC/AR/arUtil.c
@@ -447,7 +447,7 @@ const char *arUtilGetPixelFormatName(const AR_PIXEL_FORMAT arPixelFormat)
 
 const char *arUtilGetFileNameFromPath(const char *path)
 {
-	char *sep;
+	const char *sep;
 #ifdef _WIN32
     char *sep1;
 #endif
@@ -468,7 +468,7 @@ const char *arUtilGetFileNameFromPath(const char *path)
 char *arUtilGetFileBasenameFromPath(const char *path, const int convertToLowercase)
 {
     const char *file;
-    char *sep;
+    const char *sep;
     size_t len;
     char *ret;
     int i;
@@ -498,7 +498,7 @@ char *arUtilGetFileBasenameFromPath(const char *path, const int convertToLowerca
 
 char *arUtilGetFileExtensionFromPath(const char *path, const int convertToLowercase)
 {
-    char *sep;
+    const char *sep;
     size_t len;
     char *ret;
     int i;
@@ -530,7 +530,7 @@ char *arUtilGetFileExtensionFromPath(const char *path, const int convertToLowerc
 
 char *arUtilGetDirectoryNameFromPath(char *dir, const char *path, const size_t n, const int addSeparator)
 {
-	char *sep;
+	const char *sep;
 #ifdef _WIN32
     char *sep1;
 #endif


### PR DESCRIPTION
Without this simple fix I get several errors like this in `arUtil.c` in macOS 10.12.6 with clang 9.0.0 (clang-900.0.39.2)

```
artoolkit5/lib/SRC/AR/arUtil.c:458:8: error:
      assigning to 'char *' from incompatible type 'const char *'
      sep = strrchr(path, '/');
```
      